### PR TITLE
Fix: ログイン、無料登録の分岐のページのbuttonのCSSを修正

### DIFF
--- a/app/assets/stylesheets/bifurcation/bifurcation.scss
+++ b/app/assets/stylesheets/bifurcation/bifurcation.scss
@@ -19,7 +19,7 @@
             width: 300px;
             height: 64px;
         }
-        button:hover{
+        .button:hover{
             color: #5A5858;
             border: #5A5858 solid 3px;
             border-radius: 10px;


### PR DESCRIPTION
- クラス指定間違いを修正
- button → .button