### PR TITLE
Jquery

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -95,9 +95,12 @@ input,select{
 
 // お気に入りボタン
 .like_button{
-    padding-top: 20px;
-    background-color: #5A5858;
-    border: none;
+    // padding-top: 20px;
+    // background-color: #5A5858;
+    // border: none;
+    display: block;
+    margin-top: 20px;
+    color: #000;
     .fa-heart{
         font-size: 30px;
     }
@@ -108,10 +111,11 @@ input,select{
 
 @media (max-width:450px) {
     .like_button{
-        padding-top: 20px;
+        // padding-top: 20px;
+        // background-color: #5A5858;
+        // border: none;
+        margin-top: 10px;
         padding-left: 0px;
-        background-color: #5A5858;
-        border: none;
         .fa-heart{
             font-size: 25px;
         }

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,13 +1,15 @@
 class LikesController < ApplicationController
   def create
-    item = Item.find(params[:item_id])
-    current_user.like(item)
-    redirect_back(fallback_location: brand_item_path(item.brand, item))
+    @item = Item.find(params[:item_id])
+    current_user.like(@item)
+    # ajax(非同期処理に移行)
+    # redirect_back(fallback_location: brand_item_path(item.brand, item))
   end
 
   def destroy
-    item = current_user.likes.find(params[:id]).item
-    current_user.unlike(item)
-    redirect_back(fallback_location: brand_item_path(item.brand, item))
+    @item = current_user.likes.find(params[:id]).item
+    current_user.unlike(@item)
+    # ajax(非同期処理に移行)
+    # redirect_back(fallback_location: brand_item_path(item.brand, item))
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import 'jquery'
 
 Rails.start()
 Turbolinks.start()

--- a/app/views/items/_like.html.erb
+++ b/app/views/items/_like.html.erb
@@ -1,4 +1,3 @@
-<%= button_to likes_path(item_id: item.id),class:'like_button', method: :post do %>
+<%= link_to likes_path(item_id: item.id),class:'like_button', id: "js-like-button-for-item-#{item.id}", method: :post, remote: true do %>
     <i class="fa-solid fa-heart "></i>
-    <p>お気に入り<p>
 <% end %>

--- a/app/views/items/_unlike.html.erb
+++ b/app/views/items/_unlike.html.erb
@@ -1,4 +1,3 @@
-<%= button_to like_path(current_user.likes.find_by(item_id: item.id )), class:'like_button',  method: :delete do %>
+<%= link_to like_path(current_user.likes.find_by(item_id: item.id )), class:'like_button',id: "js-unlike-button-for-item-#{item.id}",  method: :delete, remote: true do %>
     <i class="fa-solid fa-heart" style="color:#fff;"></i>
-    <p>お気に入り解除<p>
 <% end %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "jquery": "^3.6.0",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3836,6 +3836,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
 お気に入りボタンを非同期処理に移行

jqueryを読み込んで行なっている。

お気に入りボタンはbuttonタグで実行していたが、aタグに変更。