### PR TITLE
crean: paramsの受け取る値を文字列からintegerで受け取るように修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,8 +12,8 @@ class ItemsController < ApplicationController
       history_item = @item.browsing_histories.new
       history_item.user_id = current_user.id
 
-      if current_user.browsing_histories.exists?(item_id: "#{params[:id]}")
-        old_history = current_user.browsing_histories.find_by(item_id: "#{params[:id]}")
+      if current_user.browsing_histories.exists?(item_id: params[:id])
+        old_history = current_user.browsing_histories.find_by(item_id: params[:id])
         old_history.destroy
       end
 


### PR DESCRIPTION
BATTLE OF RUNTEQ Vol2 レビュー #139

params[id]は integer型を受け取るため、文字列型にする必要はない